### PR TITLE
Creating password-tmp file with key store password for secure vault before docker container starts

### DIFF
--- a/wso2am/kubernetes/wso2am-api-key-manager-controller.yaml
+++ b/wso2am/kubernetes/wso2am-api-key-manager-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2am-key-manager
         image: wso2/am-api-key-manager-1.9.1:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2am/kubernetes/wso2am-api-publisher-controller.yaml
+++ b/wso2am/kubernetes/wso2am-api-publisher-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2am-api-publisher
         image: wso2/am-api-publisher-1.9.1:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2am/kubernetes/wso2am-api-store-controller.yaml
+++ b/wso2am/kubernetes/wso2am-api-store-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2am-store
         image: wso2/am-api-store-1.9.1:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2am/kubernetes/wso2am-default-controller.yaml
+++ b/wso2am/kubernetes/wso2am-default-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2am-default
         image: wso2/am-1.9.1:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 8280

--- a/wso2am/kubernetes/wso2am-gateway-manager-controller.yaml
+++ b/wso2am/kubernetes/wso2am-gateway-manager-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2am-gateway-manager
         image: wso2/am-gateway-manager-1.9.1:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 8280

--- a/wso2as/kubernetes/wso2as-default-controller.yaml
+++ b/wso2as/kubernetes/wso2as-default-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2as-default
         image: wso2/as-5.3.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 8280

--- a/wso2as/kubernetes/wso2as-manager-controller.yaml
+++ b/wso2as/kubernetes/wso2as-manager-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2as-manager
         image: wso2/as-manager-5.3.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2as/kubernetes/wso2as-worker-controller.yaml
+++ b/wso2as/kubernetes/wso2as-worker-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2as-worker
         image: wso2/as-worker-5.3.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
           -
             containerPort: 9763

--- a/wso2bps/kubernetes/wso2bps-default-controller.yaml
+++ b/wso2bps/kubernetes/wso2bps-default-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2bps-default
         image: wso2/bps-3.5.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2bps/kubernetes/wso2bps-manager-controller.yaml
+++ b/wso2bps/kubernetes/wso2bps-manager-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2bps-manager
         image: wso2/bps-manager-3.5.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2bps/kubernetes/wso2bps-worker-controller.yaml
+++ b/wso2bps/kubernetes/wso2bps-worker-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2bps-worker
         image: wso2/bps-worker-3.5.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2brs/kubernetes/wso2brs-default-controller.yaml
+++ b/wso2brs/kubernetes/wso2brs-default-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2brs-default
         image: wso2/brs-2.2.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2brs/kubernetes/wso2brs-manager-controller.yaml
+++ b/wso2brs/kubernetes/wso2brs-manager-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2brs-manager
         image: wso2/brs-manager-2.2.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2brs/kubernetes/wso2brs-worker-controller.yaml
+++ b/wso2brs/kubernetes/wso2brs-worker-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2brs-worker
         image: wso2/brs-worker-2.2.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
           -
             containerPort: 9763

--- a/wso2cep/kubernetes/wso2cep-default-controller.yaml
+++ b/wso2cep/kubernetes/wso2cep-default-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2cep-default
         image: wso2/cep-4.0.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2cep/kubernetes/wso2cep-presenter-controller.yaml
+++ b/wso2cep/kubernetes/wso2cep-presenter-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2cep-presenter
         image: wso2/cep-presenter-4.0.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
          -
           containerPort: 9763

--- a/wso2cep/kubernetes/wso2cep-worker-controller.yaml
+++ b/wso2cep/kubernetes/wso2cep-worker-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2cep-worker
         image: wso2/cep-worker-4.0.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2das/kubernetes/wso2das-default-controller.yaml
+++ b/wso2das/kubernetes/wso2das-default-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2das-default
         image: wso2/das-3.0.1:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9443

--- a/wso2dss/kubernetes/wso2dss-default-controller.yaml
+++ b/wso2dss/kubernetes/wso2dss-default-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2dss-default
         image: wso2/dss-3.5.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2dss/kubernetes/wso2dss-manager-controller.yaml
+++ b/wso2dss/kubernetes/wso2dss-manager-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2dss-manager
         image: wso2/dss-manager-3.5.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2dss/kubernetes/wso2dss-worker-controller.yaml
+++ b/wso2dss/kubernetes/wso2dss-worker-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2dss-worker
         image: wso2/dss-worker-3.5.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2es/kubernetes/wso2es-default-controller.yaml
+++ b/wso2es/kubernetes/wso2es-default-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2es-default
         image: wso2/es-2.0.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
          containerPort: 9763

--- a/wso2es/kubernetes/wso2es-publisher-controller.yaml
+++ b/wso2es/kubernetes/wso2es-publisher-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2es-publisher
         image: wso2/es-publisher-2.0.0:0.0.1
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
          containerPort: 9763

--- a/wso2es/kubernetes/wso2es-store-controller.yaml
+++ b/wso2es/kubernetes/wso2es-store-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2es-store
         image: wso2/es-store-2.0.0:0.0.1
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
          containerPort: 9763

--- a/wso2esb/kubernetes/wso2esb-default-controller.yaml
+++ b/wso2esb/kubernetes/wso2esb-default-controller.yaml
@@ -17,6 +17,10 @@ spec:
       -
         name: wso2esb-default
         image: wso2/esb-4.9.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 8280

--- a/wso2esb/kubernetes/wso2esb-manager-controller.yaml
+++ b/wso2esb/kubernetes/wso2esb-manager-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2esb-manager
         image: wso2/esb-manager-4.9.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2esb/kubernetes/wso2esb-worker-controller.yaml
+++ b/wso2esb/kubernetes/wso2esb-worker-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2esb-worker
         image: wso2/esb-worker-4.9.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 8243

--- a/wso2greg/kubernetes/wso2greg-default-controller.yaml
+++ b/wso2greg/kubernetes/wso2greg-default-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2greg-default
         image: wso2/greg-5.1.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2greg/kubernetes/wso2greg-publisher-controller.yaml
+++ b/wso2greg/kubernetes/wso2greg-publisher-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2greg-publisher
         image: wso2/greg-publisher-5.1.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
          containerPort: 9763

--- a/wso2greg/kubernetes/wso2greg-store-controller.yaml
+++ b/wso2greg/kubernetes/wso2greg-store-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2greg-store
         image: wso2/greg-store-5.1.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
          containerPort: 9763

--- a/wso2is/kubernetes/wso2is-default-controller.yaml
+++ b/wso2is/kubernetes/wso2is-default-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2is-default
         image: wso2/is-5.1.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763

--- a/wso2mb/kubernetes/wso2mb-default-controller.yaml
+++ b/wso2mb/kubernetes/wso2mb-default-controller.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
       - name: wso2mb-default
         image: wso2/mb-3.0.0:1.0.0
+#        env:
+#        -
+#          name: KEY_STORE_PASSWORD
+#          value: wso2carbon
         ports:
         -
           containerPort: 9763


### PR DESCRIPTION
This p/r is to add changes needed for secure vault so that  password-tmp file will be created with key store password for secure vault before docker container starts. 

Note that key store password is passed as environment variable to containers kubernetes replication controllers.

I'll add kubernetes secrets support to send password to containers in next release.